### PR TITLE
Fixed unexpected behavior of streams-table join in StreamsJoin example

### DIFF
--- a/kafka-streams/src/main/java/io/confluent/developer/joins/TopicLoader.java
+++ b/kafka-streams/src/main/java/io/confluent/developer/joins/TopicLoader.java
@@ -86,6 +86,13 @@ public class TopicLoader {
 
             var users = List.of(userOne, userTwo);
 
+            // Users must be created first so the KTable records have earlier timestamps than the KStream records,
+            // otherwise the join will ignore them.
+            users.forEach(user -> {
+                ProducerRecord<String, SpecificRecord> producerRecord = new ProducerRecord<>(tableTopic, user.getUserId(), user);
+                producer.send(producerRecord, callback);
+            });
+
             applianceOrders.forEach((ao -> {
                 ProducerRecord<String, SpecificRecord> producerRecord = new ProducerRecord<>(leftSideTopic, ao.getUserId(), ao);
                 producer.send(producerRecord, callback);
@@ -95,12 +102,6 @@ public class TopicLoader {
                 ProducerRecord<String, SpecificRecord> producerRecord = new ProducerRecord<>(rightSideTopic, eo.getUserId(), eo);
                 producer.send(producerRecord, callback);
             }));
-
-            users.forEach(user -> {
-                ProducerRecord<String, SpecificRecord> producerRecord = new ProducerRecord<>(tableTopic, user.getUserId(), user);
-                producer.send(producerRecord, callback);
-            });
-
         }
     }
 }


### PR DESCRIPTION
The leftJoin of the combinedStream to the usersTable was failing to join any records from the usersTable because they had later timestamps than the corresponding stream records. The fix is to modify the TopicLoader to create the users first so that they have the earliest timestamps.

For more, see https://forum.confluent.io/t/troubleshooting-streamsjoin-example-in-kafka-streams-101-course/3339