### PR TITLE
Update log4j to safe versions

### DIFF
--- a/kafka-streams/build.gradle
+++ b/kafka-streams/build.gradle
@@ -27,9 +27,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.10.2"
-    implementation "org.apache.logging.log4j:log4j-api:2.7"
-    implementation "org.apache.logging.log4j:log4j-core:2.7"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.7"
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
 
     implementation('org.apache.kafka:kafka-streams:2.8.0') {
         exclude group: 'org.apache.kafka', module: 'kafka-clients'


### PR DESCRIPTION
Updates the `log4j` dependencies to versions that eliminated the `CVE-2021-44228` vulnerabliity